### PR TITLE
Promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Change transpiler to babel-cli to support transpilation of async/await
+
 ## [1.1.0] - 2018-07-23
 ### Changed
 * Altered flow: first look in DB, then ESRI codes, then epsg.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-* Change transpiler to babel-cli to support transpilation of async/await
+* Remove async/await and rewrite with promises to support older versions of Node
 
 ## [1.1.0] - 2018-07-23
 ### Changed

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "standard && tape test/*.js | tap-spec",
     "clean": "rm -rf dist",
-    "compile": "buble -i src -o dist"
+    "compile": "babel src --out-dir dist"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/GeoXForm/spatialreference#readme",
   "devDependencies": {
-    "buble": "^0.19.3",
+    "babel-cli": "^6.26.0",
     "standard": "^11.0.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "standard && tape test/*.js | tap-spec",
     "clean": "rm -rf dist",
-    "compile": "babel src --out-dir dist"
+    "compile": "buble src -o dist"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/GeoXForm/spatialreference#readme",
   "devDependencies": {
-    "babel-cli": "^6.26.0",
+    "buble": "^0.19.3",
     "standard": "^11.0.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "standard && tape test/*.js | tap-spec",
     "clean": "rm -rf dist",
-    "compile": "buble src -o dist"
+    "compile": "buble -i src -o dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`buble` cannot compile `async/await` to ES2015 code.  Thus, compiled code was causing errors at runtime. Was not caught by tests or CI because they operate on source files, not on distribution files.  

This PR refactors the code to remove `async/await` and instead uses promises.